### PR TITLE
Circle CI作成

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+version: 2
+jobs:
+  build_and_deploy:
+    working_directory: ~/repo
+    docker:
+      - image: circleci/node:8.9
+    branches:
+        only:
+          - master
+    steps:
+      - checkout
+
+      - run:
+          name: install now
+          command: yarn global add now
+
+      - run:
+          name: deploy asap now!!
+          command: |
+            now --public -t ${ZEIT_TOKEN}
+            now alias -t
+
+workflows:
+  version: 2
+  build_deploy:
+    jobs:
+      - build_and_deploy

--- a/now.json
+++ b/now.json
@@ -1,0 +1,12 @@
+{
+  "env": {
+    "DB_USER": "@db_user",
+    "DB_PASS": "@db_pass",
+    "DB_HOST": "@db_host",
+    "DB_PORT": "@db_port",
+    "DB_NAME": "@db_name"
+  },
+  "alias": [
+    "shinjuku-lt-backend"
+  ]
+}

--- a/server.js
+++ b/server.js
@@ -41,17 +41,16 @@ mongoose.connect(`mongodb://${process.env.USER}:${process.env.PASS}@${process.en
         })
       })
       .post((req, res) => {
-          let post;
-          var body='';
+          let body = '';
           req.on('data', function (data) {
-                body +=data;
+            body += data;
           });
-          var params = req.body.text.split(" ", -1)
-          const year = params[1].slice(0,-2)
-          const month = params[1].slice(-2)
-          const user = params[2]
-          const serviceType = params[3]
-          const url = params[4]
+          const params = req.body.text.split(" ", -1);
+          const year = params[1].slice(0, -2);
+          const month = params[1].slice(-2);
+          const user = params[2];
+          const serviceType = params[3];
+          const url = params[4];
           let slide = new Slide();
           slide.publish.month = month;
           slide.publish.year = year;

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ app.use((req, res, next) => {
   next();
 });
 
-mongoose.connect(`mongodb://${process.env.USER}:${process.env.PASS}@${process.env.HOST}:${process.env.PORT}/${process.env.DB}`, err => {
+mongoose.connect(`mongodb://${process.env.DB_USER}:${process.env.DB_PASS}@${process.env.DB_HOST}:${process.env.DB_PORT}/${process.env.DB}`, err => {
 
     app.get('/health', (req, res) => {
       res.json({message: 'woooooooooooo.'});


### PR DESCRIPTION
## 概要

* 本番デプロイ用のCircle CIを設定する
* https://circleci.com/gh/shinjuku-lt/shinjuku-lt-backend

## やったこと

* 本番デプロイ用にmaster mergeをトリガーにCircle CIを走らせる
* デプロイ後にURLを `https://shinjuku-lt-backend.now.sh` に固定する
  * aliasを設定するとダウンタイムなしで新しいインスタンスにスイッチされ、古いのは消されるみたい

## やってないこと

* フロントのEP修正
